### PR TITLE
Return empty list of cards if drug is not found

### DIFF
--- a/src/hooks/hookResources.ts
+++ b/src/hooks/hookResources.ts
@@ -141,7 +141,7 @@ export async function handleHook(
         }
       } else {
         // unsupported drug code, TODO - what to do when we don't have a service url
-        res.json(createErrorCard('Unsupported Drug Code'));
+        res.json({ cards: [] });
       }
     } else {
       // drug code could not be extracted


### PR DESCRIPTION
Related ticket: https://jira.mitre.org/browse/REMS-738

Summary: Remove returning an object `{cards: [...]}` whose cards array returns the "Unsupported Drug Code" and just return `{cards: []}` when the drug code is not found.