### PR TITLE
Support patient-view and encounter-start hooks

### DIFF
--- a/.env
+++ b/.env
@@ -13,3 +13,4 @@ VITE_AUTH = http://localhost:8180
 VITE_USER = alice
 VITE_PASSWORD = alice
 VITE_CLIENT = app-login
+REMS_ADMIN_HOOK_PATH=http://localhost:8090/cds-services/rems-

--- a/src/config.ts
+++ b/src/config.ts
@@ -22,7 +22,7 @@ export type Config = {
     level: string;
   };
   general: {
-    remsAdminHookPath: string;
+    remsAdminHookPath: string | undefined;
     remsAdminFhirEtasuPath: string;
   };
   database: {
@@ -80,7 +80,7 @@ const config: Config = {
   },
   general: {
     //resourcePath: 'src/cds-library/CRD-DTR'
-    remsAdminHookPath: 'http://localhost:8090/cds-services/rems-',
+    remsAdminHookPath: env.get('REMS_ADMIN_HOOK_PATH').asString(),
     remsAdminFhirEtasuPath: 'http://localhost:8090/4_0_0/GuidanceResponse/$rems-etasu'
   },
   database: {


### PR DESCRIPTION
Add support for patient-view and encounter-start hooks. Loop through the MedicationRequests in the prefetch to build a list of REMS administrators to send the query to. Send the hook to each and combine the returned cards to send back to the client.